### PR TITLE
Fix loading error

### DIFF
--- a/course/activities/skills/continuous.yaml
+++ b/course/activities/skills/continuous.yaml
@@ -50,7 +50,7 @@ Phrases:
       - Está nadando en el mar
     Translation: She is swimming in the sea
     Alternative translations:
-      She's swimming in the sea
+      - She's swimming in the sea
 
   - Phrase: Él está comiendo chocolate
     Alternative versions:


### PR DESCRIPTION
On glossaico, when loading the spanish course, the following occurs: """
librelingo_yaml_loader.yaml_loader.ValidationError: There is an error with the schema at the following file path: [...]/spanish-from-english/course/activities/skills/continuous.yaml Original error message: "She's swimming in the sea" is not of type 'array'

Failed validating 'type' in schema['properties']['Phrases']['items']['properties']['Alternative translations']:
    {'items': {'type': 'string'}, 'type': 'array'}

On instance['Phrases'][6]['Alternative translations']:
    "She's swimming in the sea"
"""

This commit fixes the error